### PR TITLE
Centralize logging setup

### DIFF
--- a/core/proxy_benchmark.py
+++ b/core/proxy_benchmark.py
@@ -2,6 +2,8 @@ import requests
 import time
 import logging
 
+logger = logging.getLogger(__name__)
+
 def benchmark(proxy_list):
     results = []
     for proxy in proxy_list:
@@ -14,10 +16,10 @@ def benchmark(proxy_list):
             r = requests.get("http://httpbin.org/ip", proxies=proxies, timeout=5)
             elapsed = time.time() - start
             results.append((proxy, True, round(elapsed, 2)))
-            logging.info(f"[PROXY BENCH] {proxy} OK ({elapsed:.2f}s)")
+            logger.info(f"[PROXY BENCH] {proxy} OK ({elapsed:.2f}s)")
         except Exception:
             results.append((proxy, False, None))
-            logging.warning(f"[PROXY BENCH] {proxy} FAIL")
+            logger.warning(f"[PROXY BENCH] {proxy} FAIL")
     return results
 
 if __name__ == "__main__":

--- a/earn/affiliate_splitter.py
+++ b/earn/affiliate_splitter.py
@@ -2,14 +2,13 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/affiliate_splitter.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def process_batch(batch_number):
     try:
         msg_start = f"🔄 Memproses batch affiliate nomor {batch_number}"
         print(msg_start)
-        logging.info(msg_start)
+        logger.info(msg_start)
         telegram_notifier.send_telegram_message(msg_start)
 
         # Simulasi proses batch (ganti dengan logic sebenarnya)
@@ -17,18 +16,18 @@ def process_batch(batch_number):
 
         msg_done = f"✅ Selesai proses batch affiliate nomor {batch_number}"
         print(msg_done)
-        logging.info(msg_done)
+        logger.info(msg_done)
         telegram_notifier.send_telegram_message(msg_done)
 
     except Exception as e:
         err_msg = f"⚠️ Error saat proses batch {batch_number}: {str(e)}"
         print(err_msg)
-        logging.error(err_msg)
+        logger.error(err_msg)
         telegram_notifier.send_telegram_message(err_msg)
 
 def dispatch():
     telegram_notifier.send_telegram_message("🪙 Affiliate Splitter mulai berjalan.")
-    logging.info("Affiliate Splitter started.")
+    logger.info("Affiliate Splitter started.")
 
     try:
         while True:
@@ -40,5 +39,5 @@ def dispatch():
     except Exception as e:
         err_msg = f"⚠️ Error di Affiliate Splitter: {str(e)}"
         print(err_msg)
-        logging.error(err_msg)
+        logger.error(err_msg)
         telegram_notifier.send_telegram_message(err_msg)

--- a/earn/cpa_bomb.py
+++ b/earn/cpa_bomb.py
@@ -2,8 +2,7 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/cpa_bomb.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def get_cpa_links():
     # Contoh daftar link CPA, bisa diupdate sesuai kebutuhan
@@ -17,7 +16,7 @@ def access_link(link):
     try:
         msg_start = f"🔥 Mulai akses CPA link: {link}"
         print(msg_start)
-        logging.info(msg_start)
+    logger.info(msg_start)
         telegram_notifier.send_telegram_message(msg_start)
 
         # Simulasi akses link (ganti dengan request HTTP sebenarnya jika perlu)
@@ -25,18 +24,18 @@ def access_link(link):
 
         msg_done = f"✅ Selesai akses CPA link: {link}"
         print(msg_done)
-        logging.info(msg_done)
+    logger.info(msg_done)
         telegram_notifier.send_telegram_message(msg_done)
 
     except Exception as e:
         err_msg = f"⚠️ Error saat akses CPA link '{link}': {str(e)}"
         print(err_msg)
-        logging.error(err_msg)
+        logger.error(err_msg)
         telegram_notifier.send_telegram_message(err_msg)
 
 def run():
     telegram_notifier.send_telegram_message("💣 CPA Bomb mulai dijalankan.")
-    logging.info("CPA Bomb started.")
+    logger.info("CPA Bomb started.")
 
     try:
         while True:
@@ -50,5 +49,5 @@ def run():
     except Exception as e:
         err_msg = f"⚠️ Error di CPA Bomb: {str(e)}"
         print(err_msg)
-        logging.error(err_msg)
+        logger.error(err_msg)
         telegram_notifier.send_telegram_message(err_msg)

--- a/earn/daily_task_grabber.py
+++ b/earn/daily_task_grabber.py
@@ -2,21 +2,20 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/daily_task_grabber.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def start():
     telegram_notifier.send_telegram_message("🚀 daily_task_grabber mulai berjalan.")
-    logging.info("Daily Task Grabber started.")
+    logger.info("Daily Task Grabber started.")
 
     try:
         while True:
             telegram_notifier.send_telegram_message("📝 daily_task_grabber menjalankan tugas harian...")
-            logging.info("Daily Task Grabber bekerja.")
+            logger.info("Daily Task Grabber bekerja.")
             # Tambahkan logika nyata di sini
             time.sleep(300)
     except Exception as e:
         err = f"⚠️ Error di daily_task_grabber: {str(e)}"
         print(err)
-        logging.error(err)
+        logger.error(err)
         telegram_notifier.send_telegram_message(err)

--- a/earn/push_loop.py
+++ b/earn/push_loop.py
@@ -2,19 +2,18 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/push_loop.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def begin():
     telegram_notifier.send_telegram_message("🔄 Push Loop mulai berjalan.")
-    logging.info("Push Loop started.")
+    logger.info("Push Loop started.")
 
     try:
         while True:
             for i in range(1, 6):
                 msg = f"🚀 Push Loop round {i} sedang berjalan."
                 print(msg)
-                logging.info(msg)
+                logger.info(msg)
                 telegram_notifier.send_telegram_message(msg)
                 time.sleep(3)  # Simulasi kerja tiap round
 
@@ -24,5 +23,5 @@ def begin():
     except Exception as e:
         err_msg = f"⚠️ Error di Push Loop: {str(e)}"
         print(err_msg)
-        logging.error(err_msg)
+        logger.error(err_msg)
         telegram_notifier.send_telegram_message(err_msg)

--- a/earn/rotator_engine.py
+++ b/earn/rotator_engine.py
@@ -2,19 +2,18 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/rotator_engine.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def spin():
     telegram_notifier.send_telegram_message("🌀 Rotator Engine mulai bekerja.")
-    logging.info("Rotator Engine started.")
+    logger.info("Rotator Engine started.")
 
     try:
         while True:
             for i in range(1, 4):
                 msg = f"🔄 Rotator round {i} aktif."
                 print(msg)
-                logging.info(msg)
+                logger.info(msg)
                 telegram_notifier.send_telegram_message(msg)
                 time.sleep(4)  # Simulasi proses rotasi
 
@@ -24,5 +23,5 @@ def spin():
     except Exception as e:
         err_msg = f"⚠️ Error di Rotator Engine: {str(e)}"
         print(err_msg)
-        logging.error(err_msg)
+        logger.error(err_msg)
         telegram_notifier.send_telegram_message(err_msg)

--- a/earn/shortlink_blast.py
+++ b/earn/shortlink_blast.py
@@ -2,12 +2,11 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/shortlink_blast.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def fire():
     telegram_notifier.send_telegram_message("🚀 Shortlink Blast mulai dijalankan.")
-    logging.info("Shortlink Blast started.")
+    logger.info("Shortlink Blast started.")
 
     shortlinks = [
         "https://shortlink.example1.com",
@@ -20,7 +19,7 @@ def fire():
             for link in shortlinks:
                 msg = f"🔗 Mengirim trafik ke shortlink: {link}"
                 print(msg)
-                logging.info(msg)
+                logger.info(msg)
                 telegram_notifier.send_telegram_message(msg)
                 time.sleep(3)  # Simulasi delay trafik
 
@@ -30,5 +29,5 @@ def fire():
     except Exception as e:
         err_msg = f"⚠️ Error di Shortlink Blast: {str(e)}"
         print(err_msg)
-        logging.error(err_msg)
+        logger.error(err_msg)
         telegram_notifier.send_telegram_message(err_msg)

--- a/main.py
+++ b/main.py
@@ -13,15 +13,19 @@ from dashboard import app
 # Load environment variables from .env file
 load_dotenv()
 
-logging.basicConfig(filename='log/diablo_blackhat.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    filename="log/diablo_blackhat.log",
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 def run_flask():
     app.run(host="0.0.0.0", port=8080)
 
 def notify(msg):
     print(msg)
-    logging.info(msg)
+    logger.info(msg)
     telegram_notifier.send_telegram_message(msg)
 
 def startup_banner():

--- a/wallet_split/auto_withdraw.py
+++ b/wallet_split/auto_withdraw.py
@@ -3,15 +3,14 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/auto_withdraw.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def auto_withdraw_to_wallet(amount, coin="USDT", network="TRX", address=None):
     address = address or os.getenv("MAIN_WALLET_ADDRESS")
     if not address:
         error_msg = "⚠️ Penarikan gagal: alamat wallet tidak tersedia."
         print(error_msg)
-        logging.error(error_msg)
+        logger.error(error_msg)
         telegram_notifier.send_telegram_message(error_msg)
         raise Exception("Alamat wallet tidak tersedia.")
 
@@ -20,18 +19,18 @@ def auto_withdraw_to_wallet(amount, coin="USDT", network="TRX", address=None):
             f"💸 Menyiapkan penarikan otomatis\nJumlah: <b>{amount} {coin}</b>\nJaringan: <b>{network}</b>\nTujuan: <code>{address}</code>"
         )
         print(f"Menarik {amount} {coin} ke {address} via jaringan {network}...")
-        logging.info(f"Withdraw {amount} {coin} ke {address} via {network}")
+        logger.info(f"Withdraw {amount} {coin} ke {address} via {network}")
 
         # Simulasi proses penarikan, ganti dengan API nyata jika ada
         time.sleep(5)
 
         telegram_notifier.send_telegram_message("✅ Penarikan otomatis berhasil.")
-        logging.info("Penarikan otomatis berhasil.")
+        logger.info("Penarikan otomatis berhasil.")
         return True
 
     except Exception as e:
         error_msg = f"⚠️ Gagal melakukan penarikan: {str(e)}"
         print(error_msg)
-        logging.error(error_msg)
+        logger.error(error_msg)
         telegram_notifier.send_telegram_message(error_msg)
         return False

--- a/wallet_split/mirror_wallet.py
+++ b/wallet_split/mirror_wallet.py
@@ -2,20 +2,19 @@ import time
 import logging
 from core import telegram_notifier
 
-logging.basicConfig(filename='log/mirror_wallet.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 def sync():
     telegram_notifier.send_telegram_message("🪞 Mirror Wallet: sinkronisasi dimulai.")
-    logging.info("Mirror Wallet sync started.")
+    logger.info("Mirror Wallet sync started.")
 
     try:
         # Simulasi proses sinkronisasi wallet
         time.sleep(5)
         telegram_notifier.send_telegram_message("✅ Mirror Wallet: sinkronisasi selesai.")
-        logging.info("Mirror Wallet sync completed.")
+        logger.info("Mirror Wallet sync completed.")
     except Exception as e:
         error_msg = f"⚠️ Error pada Mirror Wallet: {str(e)}"
         print(error_msg)
-        logging.error(error_msg)
+        logger.error(error_msg)
         telegram_notifier.send_telegram_message(error_msg)


### PR DESCRIPTION
## Summary
- configure logging once in `main.py`
- use module loggers via `logging.getLogger(__name__)`
- remove redundant `basicConfig` calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afd96333083318ad24d6a04a04811