### PR TITLE
Remove unused env loader; centralize dotenv

### DIFF
--- a/core/.env_loader.py
+++ b/core/.env_loader.py
@@ -1,8 +1,0 @@
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
-MAIN_WALLET_ADDRESS = os.getenv("MAIN_WALLET_ADDRESS")

--- a/stats_pusher.py
+++ b/stats_pusher.py
@@ -2,9 +2,7 @@ import sqlite3
 import json
 import os
 import requests
-from dotenv import load_dotenv
-
-load_dotenv()
+from main import load_dotenv
 
 def push_stats():
     conn = sqlite3.connect("vault/earnings.db")

--- a/telegram_guard.py
+++ b/telegram_guard.py
@@ -1,8 +1,6 @@
 import os
 import requests
-from dotenv import load_dotenv
-
-load_dotenv()
+from main import load_dotenv
 
 token = os.getenv("TELEGRAM_TOKEN")
 chat_id = os.getenv("TELEGRAM_CHAT_ID")

--- a/withdraw_api.py
+++ b/withdraw_api.py
@@ -1,8 +1,6 @@
 import requests
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
+from main import load_dotenv
 
 API_ENDPOINT = "https://api.example-exchange.com/withdraw"
 API_KEY = os.getenv("EXCHANGE_API_KEY")

--- a/withdraw_tron.py
+++ b/withdraw_tron.py
@@ -1,8 +1,6 @@
 import os
 import requests
-from dotenv import load_dotenv
-
-load_dotenv()
+from main import load_dotenv
 
 TRON_API = "https://api.trongrid.io/wallet/createtransaction"
 TRX_ADDRESS = os.getenv("TRX_ADDRESS")


### PR DESCRIPTION
## Summary
- delete `core/.env_loader.py`
- rely on `main.py` to load `.env`
- remove redundant dotenv imports and calls from other modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684afd88bfb883319ee2c8081745aaa5